### PR TITLE
disable autopath for search page and define static path

### DIFF
--- a/modules/sector_search/content/node/3a7d8d6a-7573-411f-86dd-c7551c7d9d4f.yml
+++ b/modules/sector_search/content/node/3a7d8d6a-7573-411f-86dd-c7551c7d9d4f.yml
@@ -39,7 +39,7 @@ default:
     -
       alias: /search
       langcode: en
-      pathauto: 1
+      pathauto: 0
   rh_action:
     -
       value: bundle_default


### PR DESCRIPTION
This fix the  search page not having  any path define after the installation process.  The reason it's because a conflict with the aliases  patterns. 